### PR TITLE
Экран профиля с возможностью смены аккаунта

### DIFF
--- a/app/src/main/java/ru/dsaime/npchat/MainActivity.kt
+++ b/app/src/main/java/ru/dsaime/npchat/MainActivity.kt
@@ -35,7 +35,11 @@ import ru.dsaime.npchat.screens.control.main.ControlDialogContent
 import ru.dsaime.npchat.screens.control.main.ControlEffect
 import ru.dsaime.npchat.screens.control.main.ControlReq
 import ru.dsaime.npchat.screens.control.profile.ProfileDialogContent
+import ru.dsaime.npchat.screens.control.profile.ProfileEffect
 import ru.dsaime.npchat.screens.control.profile.ProfileReq
+import ru.dsaime.npchat.screens.control.profile.session.logout.LogoutDialogContent
+import ru.dsaime.npchat.screens.control.profile.session.logout.LogoutEffect
+import ru.dsaime.npchat.screens.control.profile.session.logout.LogoutReq
 import ru.dsaime.npchat.screens.home.HomeEffect
 import ru.dsaime.npchat.screens.home.HomeScreenDestination
 import ru.dsaime.npchat.screens.hosts.add.AddHostDialogContent
@@ -51,10 +55,10 @@ import ru.dsaime.npchat.screens.registration.RegistrationScreenDestination
 import ru.dsaime.npchat.screens.splash.SplashEffect
 import ru.dsaime.npchat.screens.splash.SplashScreenDestination
 import ru.dsaime.npchat.ui.components.LeftButton
-import ru.dsaime.npchat.ui.dialog.BottomDialog
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
-import ru.dsaime.npchat.ui.dialog.BottomDialogProperties
-import ru.dsaime.npchat.ui.dialog.BottomDialogProperty
+import ru.dsaime.npchat.ui.components.dialog.BottomDialog
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogProperties
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogProperty
 import ru.dsaime.npchat.ui.theme.Black
 import ru.dsaime.npchat.ui.theme.NPChatTheme
 
@@ -120,6 +124,7 @@ class MainActivity : ComponentActivity() {
                         is HostSelectReq -> HostSelectDialogContent { navController.navRequestHandle(it, dialogs) }
                         is AddHostReq -> AddHostDialogContent { navController.navRequestHandle(it, dialogs) }
                         is ProfileReq -> ProfileDialogContent { navController.navRequestHandle(it, dialogs) }
+                        is LogoutReq -> LogoutDialogContent { navController.navRequestHandle(it, dialogs) }
                     }
                 }
                 NavHost(
@@ -164,6 +169,11 @@ fun NavController.navRequestHandle(
     req: Any,
     dialogs: MutableList<Any>,
 ) {
+    val navigate: (String) -> Unit = {
+        this.navigate(it)
+        dialogs.clear()
+    }
+
     when (req) {
         // Экраны /////////////////////
 
@@ -175,14 +185,10 @@ fun NavController.navRequestHandle(
         SplashEffect.Navigation.Login,
         -> navigate(ROUTE_LOGIN)
 
-        ControlEffect.Navigation.Logout -> {
-            navigate(ROUTE_LOGIN)
-            dialogs.clear()
-        }
-
         LoginEffect.Navigation.Registration -> navigate(ROUTE_REGISTRATION)
 
         HomeEffect.Navigation.Chats -> navigate(ROUTE_CHATS)
+        LogoutEffect.Navigation.Login -> navigate(ROUTE_LOGIN)
 
         // Диалоги /////////////////////
 
@@ -204,6 +210,7 @@ fun NavController.navRequestHandle(
         LoginEffect.Navigation.HostSelect -> dialogs.add(HostSelectReq)
         HostSelectEffect.Navigation.AddHost -> dialogs.add(AddHostReq)
         ControlEffect.Navigation.Profile -> dialogs.add(ProfileReq)
+        ProfileEffect.Navigation.Logout -> dialogs.add(LogoutReq)
     }
 }
 

--- a/app/src/main/java/ru/dsaime/npchat/MainActivity.kt
+++ b/app/src/main/java/ru/dsaime/npchat/MainActivity.kt
@@ -34,6 +34,8 @@ import ru.dsaime.npchat.screens.chat.create.CreateChatReq
 import ru.dsaime.npchat.screens.control.main.ControlDialogContent
 import ru.dsaime.npchat.screens.control.main.ControlEffect
 import ru.dsaime.npchat.screens.control.main.ControlReq
+import ru.dsaime.npchat.screens.control.profile.ProfileDialogContent
+import ru.dsaime.npchat.screens.control.profile.ProfileReq
 import ru.dsaime.npchat.screens.home.HomeEffect
 import ru.dsaime.npchat.screens.home.HomeScreenDestination
 import ru.dsaime.npchat.screens.hosts.add.AddHostDialogContent
@@ -117,6 +119,7 @@ class MainActivity : ComponentActivity() {
                         is CreateChatReq -> CreateChatDialogContent(showBackButton) { navController.navRequestHandle(it, dialogs) }
                         is HostSelectReq -> HostSelectDialogContent { navController.navRequestHandle(it, dialogs) }
                         is AddHostReq -> AddHostDialogContent { navController.navRequestHandle(it, dialogs) }
+                        is ProfileReq -> ProfileDialogContent { navController.navRequestHandle(it, dialogs) }
                     }
                 }
                 NavHost(
@@ -172,7 +175,7 @@ fun NavController.navRequestHandle(
         SplashEffect.Navigation.Login,
         -> navigate(ROUTE_LOGIN)
 
-        ControlEffect.Navigation.Login -> {
+        ControlEffect.Navigation.Logout -> {
             navigate(ROUTE_LOGIN)
             dialogs.clear()
         }
@@ -200,6 +203,7 @@ fun NavController.navRequestHandle(
         ControlEffect.Navigation.CreateChat -> dialogs.add(CreateChatReq)
         LoginEffect.Navigation.HostSelect -> dialogs.add(HostSelectReq)
         HostSelectEffect.Navigation.AddHost -> dialogs.add(AddHostReq)
+        ControlEffect.Navigation.Profile -> dialogs.add(ProfileReq)
     }
 }
 

--- a/app/src/main/java/ru/dsaime/npchat/data/ApiModel.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/ApiModel.kt
@@ -82,7 +82,7 @@ object ApiModel {
 
     data class ChatsResp(
         @SerializedName("next_page_token") val nextPageToken: String?,
-        @SerializedName("Chats") val chats: List<Chat>,
+        @SerializedName("Chats") val chats: List<Chat>?,
     )
 
     data class CreateChatBody(

--- a/app/src/main/java/ru/dsaime/npchat/data/ApiModel.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/ApiModel.kt
@@ -30,18 +30,28 @@ object ApiModel {
         @SerializedName("session") val session: Session,
     )
 
+    data class MeResp(
+        @SerializedName("User") val user: User,
+    )
+
     data class User(
         @SerializedName("ID") val id: String,
         @SerializedName("Name") val name: String,
         @SerializedName("Nick") val nick: String,
+        @SerializedName("BasicAuth") val basicAuth: BasicAuth,
     ) {
         fun toModel() =
             ru.dsaime.npchat.model.User(
                 id = id,
                 name = name,
                 nick = nick,
+                login = basicAuth.login,
             )
     }
+
+    data class BasicAuth(
+        @SerializedName("Login") val login: String,
+    )
 
     data class Session(
         @SerializedName("ID") val id: String,

--- a/app/src/main/java/ru/dsaime/npchat/data/BasicAuthServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/BasicAuthServiceBase.kt
@@ -50,6 +50,7 @@ fun ApiModel.AuthResp.toModel(): BasicAuthService.AuthResult =
                 id = user.id,
                 name = user.name,
                 nick = user.nick,
+                login = user.basicAuth.login,
             ),
         session =
             Session(

--- a/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
@@ -13,10 +13,11 @@ class ChatsServiceBase(
             .chats(pageToken)
             .mapCatching {
                 MyChatsResult(
-                    chats = it.chats.map(ApiModel.Chat::toModel),
+                    chats = it.chats?.map(ApiModel.Chat::toModel).orEmpty(),
                     nextPageToken = it.nextPageToken.orEmpty(),
                 ).run(::Ok)
-            }.getOrElse { Err(it.toUserMessage()) }
+            }.getOrThrow()
+//            }.getOrElse { Err(it.toUserMessage()) }
 
     override suspend fun create(name: String): Result<Chat, String> =
         api

--- a/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
@@ -16,8 +16,8 @@ class ChatsServiceBase(
                     chats = it.chats?.map(ApiModel.Chat::toModel).orEmpty(),
                     nextPageToken = it.nextPageToken.orEmpty(),
                 ).run(::Ok)
-            }.getOrThrow()
-//            }.getOrElse { Err(it.toUserMessage()) }
+//            }.getOrThrow()
+            }.getOrElse { Err(it.toUserMessage()) }
 
     override suspend fun create(name: String): Result<Chat, String> =
         api

--- a/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/ChatsServiceBase.kt
@@ -16,7 +16,6 @@ class ChatsServiceBase(
                     chats = it.chats?.map(ApiModel.Chat::toModel).orEmpty(),
                     nextPageToken = it.nextPageToken.orEmpty(),
                 ).run(::Ok)
-//            }.getOrThrow()
             }.getOrElse { Err(it.toUserMessage()) }
 
     override suspend fun create(name: String): Result<Chat, String> =

--- a/app/src/main/java/ru/dsaime/npchat/data/Interfaces.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/Interfaces.kt
@@ -65,6 +65,8 @@ interface SessionsService {
 
     suspend fun refresh(session: Session): Boolean
 
+    suspend fun revoke(session: Session)
+
     suspend fun me(): Result<User, String>
 }
 

--- a/app/src/main/java/ru/dsaime/npchat/data/Interfaces.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/Interfaces.kt
@@ -64,6 +64,8 @@ interface SessionsService {
     suspend fun isActual(session: Session): Boolean
 
     suspend fun refresh(session: Session): Boolean
+
+    suspend fun me(): Result<User, String>
 }
 
 // Описывает интерфейс доступа к потоку событий

--- a/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
@@ -27,7 +27,7 @@ interface NPChatApi {
         @Body body: ApiModel.LoginBody,
     ): Result<ApiModel.AuthResp>
 
-    @POST("/sessions/:id/revoke")
+    @POST("/sessions/{id}/revoke")
     suspend fun revoke(
         @Path("id") id: String,
     ): Result<ApiModel.AuthResp>

--- a/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
@@ -28,7 +28,7 @@ interface NPChatApi {
     ): Result<ApiModel.AuthResp>
 
     @GET("/me")
-    suspend fun me(): Result<ApiModel.User>
+    suspend fun me(): Result<ApiModel.MeResp>
 
     @GET("/chats")
     suspend fun chats(

--- a/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/NPChatApi.kt
@@ -27,6 +27,11 @@ interface NPChatApi {
         @Body body: ApiModel.LoginBody,
     ): Result<ApiModel.AuthResp>
 
+    @POST("/sessions/:id/revoke")
+    suspend fun revoke(
+        @Path("id") id: String,
+    ): Result<ApiModel.AuthResp>
+
     @GET("/me")
     suspend fun me(): Result<ApiModel.MeResp>
 
@@ -44,7 +49,4 @@ interface NPChatApi {
     suspend fun leaveChat(
         @Path("chatId") chatId: String,
     ): Result<Unit>
-//    @GET("/events")
-//    @Streaming
-//    suspend fun events(): Response<ResponseBody>
 }

--- a/app/src/main/java/ru/dsaime/npchat/data/SessionsServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/SessionsServiceBase.kt
@@ -62,6 +62,15 @@ class SessionsServiceBase(
         TODO("Not yet implemented")
     }
 
+    override suspend fun revoke(session: Session) {
+        db.sessionDao().deleteAll()
+        try {
+            api.revoke(session.id)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     override suspend fun me(): Result<User, String> =
         with(Dispatchers.IO) {
             api

--- a/app/src/main/java/ru/dsaime/npchat/data/SessionsServiceBase.kt
+++ b/app/src/main/java/ru/dsaime/npchat/data/SessionsServiceBase.kt
@@ -1,5 +1,8 @@
 package ru.dsaime.npchat.data
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -10,6 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import ru.dsaime.npchat.data.room.AppDatabase
 import ru.dsaime.npchat.model.Session
+import ru.dsaime.npchat.model.User
 
 class SessionsServiceBase(
     private val api: NPChatApi,
@@ -57,4 +61,12 @@ class SessionsServiceBase(
     override suspend fun refresh(session: Session): Boolean {
         TODO("Not yet implemented")
     }
+
+    override suspend fun me(): Result<User, String> =
+        with(Dispatchers.IO) {
+            api
+                .me()
+                .mapCatching { Ok(it.user.toModel()) }
+                .getOrElse { Err(it.toUserMessage()) }
+        }
 }

--- a/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
+++ b/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
@@ -34,6 +34,7 @@ import ru.dsaime.npchat.network.retrofit
 import ru.dsaime.npchat.screens.chat.chats.ChatsViewModel
 import ru.dsaime.npchat.screens.chat.create.CreateChatViewModel
 import ru.dsaime.npchat.screens.control.main.ControlViewModel
+import ru.dsaime.npchat.screens.control.profile.ProfileViewModel
 import ru.dsaime.npchat.screens.home.HomeViewModel
 import ru.dsaime.npchat.screens.hosts.add.AddHostViewModel
 import ru.dsaime.npchat.screens.hosts.select.HostSelectViewModel
@@ -109,4 +110,5 @@ val appModule =
         viewModelOf(::ControlViewModel)
         viewModelOf(::HostSelectViewModel)
         viewModelOf(::AddHostViewModel)
+        viewModelOf(::ProfileViewModel)
     }

--- a/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
+++ b/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
@@ -35,6 +35,7 @@ import ru.dsaime.npchat.screens.chat.chats.ChatsViewModel
 import ru.dsaime.npchat.screens.chat.create.CreateChatViewModel
 import ru.dsaime.npchat.screens.control.main.ControlViewModel
 import ru.dsaime.npchat.screens.control.profile.ProfileViewModel
+import ru.dsaime.npchat.screens.control.profile.session.logout.LogoutViewModel
 import ru.dsaime.npchat.screens.home.HomeViewModel
 import ru.dsaime.npchat.screens.hosts.add.AddHostViewModel
 import ru.dsaime.npchat.screens.hosts.select.HostSelectViewModel
@@ -111,5 +112,5 @@ val appModule =
         viewModelOf(::HostSelectViewModel)
         viewModelOf(::AddHostViewModel)
         viewModelOf(::ProfileViewModel)
-        viewModelOf(::LogoutViewMomdel)
+        viewModelOf(::LogoutViewModel)
     }

--- a/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
+++ b/app/src/main/java/ru/dsaime/npchat/di/koin/AppModule.kt
@@ -111,4 +111,5 @@ val appModule =
         viewModelOf(::HostSelectViewModel)
         viewModelOf(::AddHostViewModel)
         viewModelOf(::ProfileViewModel)
+        viewModelOf(::LogoutViewMomdel)
     }

--- a/app/src/main/java/ru/dsaime/npchat/model/User.kt
+++ b/app/src/main/java/ru/dsaime/npchat/model/User.kt
@@ -1,8 +1,8 @@
 package ru.dsaime.npchat.model
 
-
 data class User(
     val id: String,
     val name: String,
     val nick: String,
+    val login: String?,
 )

--- a/app/src/main/java/ru/dsaime/npchat/screens/chat/create/Create.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/chat/create/Create.kt
@@ -19,7 +19,7 @@ import ru.dsaime.npchat.common.functions.toast
 import ru.dsaime.npchat.data.ChatsService
 import ru.dsaime.npchat.ui.components.Input
 import ru.dsaime.npchat.ui.components.LeftButton
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
 
 object CreateChatReq
 

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/main/Main.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/main/Main.kt
@@ -52,7 +52,9 @@ sealed interface ControlEffect {
     sealed interface Navigation : ControlEffect {
         object CreateChat : Navigation
 
-        object Login : Navigation
+        object Profile : Navigation
+
+        object Logout : Navigation
     }
 }
 
@@ -65,8 +67,8 @@ class ControlViewModel(
     override fun handleEvents(event: ControlEvent) {
         when (event) {
             ControlEvent.CreateChat -> ControlEffect.Navigation.CreateChat.emit()
-            ControlEvent.Profile -> {}
-            ControlEvent.ProfileExit -> ControlEffect.Navigation.Login.emit()
+            ControlEvent.Profile -> ControlEffect.Navigation.Profile.emit()
+            ControlEvent.ProfileExit -> ControlEffect.Navigation.Logout.emit()
         }
     }
 }

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/main/Main.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/main/Main.kt
@@ -12,7 +12,7 @@ import ru.dsaime.npchat.common.base.BaseViewModel
 import ru.dsaime.npchat.data.HostService
 import ru.dsaime.npchat.data.SessionsService
 import ru.dsaime.npchat.ui.components.LeftButton
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
 
 object ControlReq
 
@@ -35,15 +35,12 @@ fun ControlDialogContent(onNavigationRequest: (ControlEffect.Navigation) -> Unit
     BottomDialogHeader("Управление")
     LeftButton("Создать чат", vm.eventHandler(ControlEvent.CreateChat))
     LeftButton("Профиль", vm.eventHandler(ControlEvent.Profile))
-    LeftButton("Выйти", vm.eventHandler(ControlEvent.ProfileExit), isRight = true)
 }
 
 sealed interface ControlEvent {
     object CreateChat : ControlEvent
 
     object Profile : ControlEvent
-
-    object ProfileExit : ControlEvent
 }
 
 object ControlState
@@ -53,8 +50,6 @@ sealed interface ControlEffect {
         object CreateChat : Navigation
 
         object Profile : Navigation
-
-        object Logout : Navigation
     }
 }
 
@@ -68,7 +63,6 @@ class ControlViewModel(
         when (event) {
             ControlEvent.CreateChat -> ControlEffect.Navigation.CreateChat.emit()
             ControlEvent.Profile -> ControlEffect.Navigation.Profile.emit()
-            ControlEvent.ProfileExit -> ControlEffect.Navigation.Logout.emit()
         }
     }
 }

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/profile/Profile.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/profile/Profile.kt
@@ -1,0 +1,91 @@
+package ru.dsaime.npchat.screens.control.profile
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import org.koin.androidx.compose.koinViewModel
+import ru.dsaime.npchat.common.base.BaseViewModel
+import ru.dsaime.npchat.data.SessionsService
+import ru.dsaime.npchat.model.User
+import ru.dsaime.npchat.ui.components.LeftButton
+import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.dialog.BottomDialogProperties
+import ru.dsaime.npchat.ui.dialog.BottomDialogProperty
+
+object ProfileReq
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileDialogContent(onNavigationRequest: (ProfileEffect.Navigation) -> Unit) {
+    val vm = koinViewModel<ProfileViewModel>()
+    val state = vm.viewState.collectAsState().value
+
+    LaunchedEffect(1) {
+        vm.effect
+            .onEach { effect ->
+                when (effect) {
+                    is ProfileEffect.Navigation -> onNavigationRequest(effect)
+                }
+            }.collect()
+    }
+
+    val profile = state.profile
+    if (profile == null) {
+        return
+    }
+
+    BottomDialogHeader("Мой профиль")
+    BottomDialogProperties(
+        BottomDialogProperty(name = "ID", value = profile.id),
+        BottomDialogProperty(name = "Name", value = profile.name),
+        BottomDialogProperty(name = "Nick", value = profile.nick),
+        BottomDialogProperty(name = "Login", value = "noval"),
+    )
+    LeftButton("Редактировать", vm.eventHandler(ProfileEvent.EditProfile))
+    LeftButton("Список сессий", vm.eventHandler(ProfileEvent.Sessions))
+    LeftButton("Завершить сессию", vm.eventHandler(ProfileEvent.EndSession))
+}
+
+sealed interface ProfileEvent {
+    object EditProfile : ProfileEvent
+
+    object Sessions : ProfileEvent
+
+    object EndSession : ProfileEvent
+
+    object Back : ProfileEvent
+}
+
+data class ProfileState(
+    val profile: User? = null,
+)
+
+sealed interface ProfileEffect {
+    sealed interface Navigation : ProfileEffect {
+        object EditProfile : Navigation
+
+        object Sessions : Navigation
+
+        object EndSession : Navigation
+
+        object Back : Navigation
+    }
+}
+
+class ProfileViewModel(
+    private val sessionsService: SessionsService,
+) : BaseViewModel<ProfileEvent, ProfileState, ProfileEffect>() {
+    override fun setInitialState() = ProfileState()
+
+    override fun handleEvents(event: ProfileEvent) {
+        when (event) {
+            ProfileEvent.Back -> ProfileEffect.Navigation.Back.emit()
+            ProfileEvent.EditProfile -> ProfileEffect.Navigation.EditProfile.emit()
+            ProfileEvent.EndSession -> ProfileEffect.Navigation.EndSession.emit()
+            ProfileEvent.Sessions -> ProfileEffect.Navigation.Sessions.emit()
+        }
+    }
+}

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/profile/Profile.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/profile/Profile.kt
@@ -17,9 +17,9 @@ import ru.dsaime.npchat.common.base.BaseViewModel
 import ru.dsaime.npchat.data.SessionsService
 import ru.dsaime.npchat.model.User
 import ru.dsaime.npchat.ui.components.LeftButton
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
-import ru.dsaime.npchat.ui.dialog.BottomDialogProperties
-import ru.dsaime.npchat.ui.dialog.BottomDialogProperty
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogProperties
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogProperty
 import ru.dsaime.npchat.ui.theme.Font
 
 object ProfileReq
@@ -87,7 +87,7 @@ sealed interface ProfileEffect {
 
         object Sessions : Navigation
 
-        object EndSession : Navigation
+        object Logout : Navigation
 
         object Back : Navigation
     }
@@ -114,7 +114,7 @@ class ProfileViewModel(
         when (event) {
             ProfileEvent.Back -> ProfileEffect.Navigation.Back.emit()
             ProfileEvent.EditProfile -> ProfileEffect.Navigation.EditProfile.emit()
-            ProfileEvent.EndSession -> ProfileEffect.Navigation.EndSession.emit()
+            ProfileEvent.EndSession -> ProfileEffect.Navigation.Logout.emit()
             ProfileEvent.Sessions -> ProfileEffect.Navigation.Sessions.emit()
         }
     }

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/profile/session/Session.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/profile/session/Session.kt
@@ -1,0 +1,4 @@
+package ru.dsaime.npchat.screens.control.profile.session
+
+class Session {
+}

--- a/app/src/main/java/ru/dsaime/npchat/screens/control/profile/session/logout/Logout.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/control/profile/session/logout/Logout.kt
@@ -1,0 +1,77 @@
+package ru.dsaime.npchat.screens.control.profile.session.logout
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
+import ru.dsaime.npchat.common.base.BaseViewModel
+import ru.dsaime.npchat.data.SessionsService
+import ru.dsaime.npchat.ui.components.LeftButton
+import ru.dsaime.npchat.ui.components.Paragraph
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
+
+object LogoutReq
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogoutDialogContent(onNavigationRequest: (LogoutEffect.Navigation) -> Unit) {
+    val vm = koinViewModel<LogoutViewModel>()
+    val state = vm.viewState.collectAsState().value
+
+    LaunchedEffect(1) {
+        vm.effect
+            .onEach { effect ->
+                when (effect) {
+                    is LogoutEffect.Navigation -> onNavigationRequest(effect)
+                }
+            }.collect()
+    }
+
+    BottomDialogHeader("Завершить сессию")
+    Paragraph(
+        "Чтобы снова войти в профиль, вам придется на" +
+            "экране входа в приложение воспользоваться " +
+            "одним из подключенных методов аутентификации.",
+    )
+    Paragraph("Вы действительно хотите выйти из своего профиля?")
+    LeftButton("Подтвердить", vm.eventHandler(LogoutEvent.Confirm), isRight = true)
+}
+
+sealed interface LogoutEvent {
+    object Confirm : LogoutEvent
+
+    object Back : LogoutEvent
+}
+
+object LogoutState
+
+sealed interface LogoutEffect {
+    sealed interface Navigation : LogoutEffect {
+        object Login : Navigation
+
+        object Back : Navigation
+    }
+}
+
+class LogoutViewModel(
+    private val sessionsService: SessionsService,
+) : BaseViewModel<LogoutEvent, LogoutState, LogoutEffect>() {
+    override fun setInitialState() = LogoutState
+
+    override fun handleEvents(event: LogoutEvent) {
+        when (event) {
+            LogoutEvent.Back -> LogoutEffect.Navigation.Back.emit()
+            LogoutEvent.Confirm ->
+                viewModelScope.launch {
+                    val session = sessionsService.currentSession() ?: return@launch
+                    sessionsService.revoke(session)
+                    LogoutEffect.Navigation.Login.emit()
+                }
+        }
+    }
+}

--- a/app/src/main/java/ru/dsaime/npchat/screens/hosts/add/AddHost.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/hosts/add/AddHost.kt
@@ -21,7 +21,7 @@ import ru.dsaime.npchat.model.Host
 import ru.dsaime.npchat.ui.components.HostStatusIcon
 import ru.dsaime.npchat.ui.components.Input
 import ru.dsaime.npchat.ui.components.LeftButton
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
 
 object AddHostReq
 

--- a/app/src/main/java/ru/dsaime/npchat/screens/hosts/select/HostSelect.kt
+++ b/app/src/main/java/ru/dsaime/npchat/screens/hosts/select/HostSelect.kt
@@ -20,7 +20,7 @@ import ru.dsaime.npchat.ui.components.Gap
 import ru.dsaime.npchat.ui.components.HostStatusIcon
 import ru.dsaime.npchat.ui.components.LeftButton
 import ru.dsaime.npchat.ui.components.RadioButton
-import ru.dsaime.npchat.ui.dialog.BottomDialogHeader
+import ru.dsaime.npchat.ui.components.dialog.BottomDialogHeader
 import ru.dsaime.npchat.ui.theme.Dp16
 import ru.dsaime.npchat.ui.theme.Font
 

--- a/app/src/main/java/ru/dsaime/npchat/ui/components/Paragraph.kt
+++ b/app/src/main/java/ru/dsaime/npchat/ui/components/Paragraph.kt
@@ -1,0 +1,23 @@
+package ru.dsaime.npchat.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ru.dsaime.npchat.ui.theme.Dp8
+import ru.dsaime.npchat.ui.theme.Font
+
+@Composable
+fun Paragraph(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .padding(Dp8)
+                .then(modifier),
+        style = Font.Text16W400,
+    )
+}

--- a/app/src/main/java/ru/dsaime/npchat/ui/components/dialog/BottomDialog.kt
+++ b/app/src/main/java/ru/dsaime/npchat/ui/components/dialog/BottomDialog.kt
@@ -1,4 +1,4 @@
-package ru.dsaime.npchat.ui.dialog
+package ru.dsaime.npchat.ui.components.dialog
 
 import android.content.ClipData
 import androidx.compose.animation.animateContentSize
@@ -102,8 +102,6 @@ data class BottomDialogProperty(
 fun BottomDialogHeader(
     title: String,
     onBack: (() -> Unit)? = null,
-//    isBackVisible: Boolean = false,
-//    onBack: () -> Unit = { },
 ) {
     Row(
         modifier = Modifier.padding(bottom = 20.dp),

--- a/app/src/main/java/ru/dsaime/npchat/ui/dialog/BottomDialog.kt
+++ b/app/src/main/java/ru/dsaime/npchat/ui/dialog/BottomDialog.kt
@@ -1,5 +1,6 @@
 package ru.dsaime.npchat.ui.dialog
 
+import android.content.ClipData
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -19,12 +20,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import ru.dsaime.npchat.common.functions.runSuspend
 import ru.dsaime.npchat.ui.components.Gap
 import ru.dsaime.npchat.ui.theme.ColorBG
 import ru.dsaime.npchat.ui.theme.ColorScrim
@@ -52,7 +58,21 @@ fun BottomDialogProperty(property: BottomDialogProperty) {
                 style = Font.Property16W400,
             )
         } else {
-            Text(property.value, style = Font.Text16W400)
+            val clipboard = LocalClipboard.current
+            val coroutineScope = rememberCoroutineScope()
+            Text(
+                property.value,
+                style = Font.Text16W400,
+                modifier =
+                    Modifier.clickable {
+                        coroutineScope.launch {
+                            ClipData
+                                .newPlainText(property.name, property.value)
+                                .toClipEntry()
+                                .runSuspend(clipboard::setClipEntry)
+                        }
+                    },
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Enable user profile viewing and session logout through bottom sheet dialogs, implement session revocation and current user retrieval in the service layer, refactor dialog components package, and improve clipboard support and chat list null safety

New Features:
- Introduce Profile bottom dialog showing user details with edit, sessions, and logout actions
- Add Logout confirmation dialog to revoke the current session and navigate back to login
- Enable copying bottom dialog property values to clipboard on click

Bug Fixes:
- Prevent NPE when mapping nullable chat lists in ChatsServiceBase

Enhancements:
- Refactor dialog components into ui.components.dialog and update imports across screens
- Extend SessionsService with revoke and me operations and update API interface, data models, and DI registration
- Add Paragraph composable for styled text in dialogs

Chores:
- Register ProfileViewModel and LogoutViewModel in DI module and update import paths for BottomDialogHeader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые функции
  - Экран профиля: просмотр ID, имени, ника и логина, с быстрыми действиями — редактировать профиль, открыть сессии, выйти.
  - Диалог подтверждения выхода из аккаунта; после подтверждения выполняется выход и переход на экран входа.

- Исправления ошибок
  - Устранена возможная ошибка при загрузке списка чатов — пустые списки теперь обрабатываются корректно.

- Рефакторинг
  - Улучшена навигация и поведение диалогов на главном экране для более предсказуемого взаимодействия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->